### PR TITLE
Simple http server

### DIFF
--- a/handlers/hello.go
+++ b/handlers/hello.go
@@ -1,23 +1,22 @@
 package handlers
 
 import (
-    "net/http"
-    "log"
-    "fmt"
+	"fmt"
+	"log"
+	"net/http"
 )
 
 type Hello struct {
-    l *log.Logger
+	l *log.Logger
 }
 
 // Constructor
 func NewHello(l *log.Logger) *Hello {
-    return &Hello{l}
+	return &Hello{l}
 }
 
 // HTTP Handler
 func (h *Hello) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
-    h.l.Println("Received Request to Hello Handler")
-    fmt.Fprint(rw, "Hello, world!")
+	h.l.Println("Received Request to Hello Handler")
+	fmt.Fprint(rw, "Hello, world!")
 }
-

--- a/handlers/hello.go
+++ b/handlers/hello.go
@@ -1,9 +1,23 @@
 package handlers
 
 import (
+    "net/http"
+    "log"
     "fmt"
 )
 
-func HandlerHello() {
-    fmt.Println("Nothing here yet")
+type Hello struct {
+    l *log.Logger
 }
+
+// Constructor
+func NewHello(l *log.Logger) *Hello {
+    return &Hello{l}
+}
+
+// HTTP Handler
+func (h *Hello) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+    h.l.Println("Hello Handler request incomming")
+    fmt.Fprint(rw, "Hello, world!")
+}
+

--- a/handlers/hello.go
+++ b/handlers/hello.go
@@ -17,7 +17,7 @@ func NewHello(l *log.Logger) *Hello {
 
 // HTTP Handler
 func (h *Hello) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
-    h.l.Println("Hello Handler request incomming")
+    h.l.Println("Received Request to Hello Handler")
     fmt.Fprint(rw, "Hello, world!")
 }
 

--- a/handlers/hello.go
+++ b/handlers/hello.go
@@ -1,0 +1,9 @@
+package handlers
+
+import (
+    "fmt"
+)
+
+func HandlerHello() {
+    fmt.Println("Nothing here yet")
+}

--- a/main.go
+++ b/main.go
@@ -1,55 +1,55 @@
 package main
 
 import (
-    "net/http"
-    "os"
-    "os/signal"
-    "context"
-    "log"
-    "time"
-    "github.com/alfiehiscox/go-practice-service/handlers"
+	"context"
+	"github.com/alfiehiscox/go-practice-service/handlers"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"time"
 )
 
 func main() {
-    l := log.New(os.Stdout, " go-practice-service", log.LstdFlags)
-    
-    // Handler
-    hh := handlers.NewHello(l)
+	l := log.New(os.Stdout, " go-practice-service", log.LstdFlags)
 
-    // ServeMux on index of port
-    sm := http.NewServeMux()
-    sm.Handle("/", hh)
+	// Handler
+	hh := handlers.NewHello(l)
 
-    // Server Configuration
-    s := http.Server{
-        Addr: ":8080",
-        Handler: sm,
-        ErrorLog: l,
-        ReadTimeout: 5 * time.Second, 
-        WriteTimeout: 10 * time.Second,
-        IdleTimeout: 120 * time.Second,
-    }
+	// ServeMux on index of port
+	sm := http.NewServeMux()
+	sm.Handle("/", hh)
 
-    // Using goroutine to handle exiting gracefully
-    go func() {
-        l.Println("Started listening on Port: 8080")
-        err := s.ListenAndServe()
-        if err != nil {
-            l.Printf("Server Info: %s\n", err)
-            os.Exit(1)
-        }
-    }()
+	// Server Configuration
+	s := http.Server{
+		Addr:         ":8080",
+		Handler:      sm,
+		ErrorLog:     l,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
 
-    // Make Channel to listen to signals on the goroutine
-    c := make(chan os.Signal, 1)
-    signal.Notify(c, os.Interrupt)
-    signal.Notify(c, os.Kill)
+	// Using goroutine to handle exiting gracefully
+	go func() {
+		l.Println("Started listening on Port: 8080")
+		err := s.ListenAndServe()
+		if err != nil {
+			l.Printf("Server Info: %s\n", err)
+			os.Exit(1)
+		}
+	}()
 
-    // Listen to the channel and exit gracefully
-    sig := <-c
-    l.Println("Got Signal: ", sig)
-    ctx, cancel := context.WithTimeout(context.Background(), 30 * time.Second)
-    defer cancel()
-    s.Shutdown(ctx)
+	// Make Channel to listen to signals on the goroutine
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	signal.Notify(c, os.Kill)
+
+	// Listen to the channel and exit gracefully
+	sig := <-c
+	l.Println("Got Signal: ", sig)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	s.Shutdown(ctx)
 
 }

--- a/main.go
+++ b/main.go
@@ -2,8 +2,11 @@ package main
 
 import (
     "fmt"
+    "net/http"
+    "os"
+    "log"
 )
 
 func main() {
-    fmt.Println("Hello, world")
+    l := log.New(os.Stdout, " go-practice-service", log.LstdFlags)
 }

--- a/main.go
+++ b/main.go
@@ -1,12 +1,55 @@
 package main
 
 import (
-    "fmt"
     "net/http"
     "os"
+    "os/signal"
+    "context"
     "log"
+    "time"
+    "github.com/alfiehiscox/go-practice-service/handlers"
 )
 
 func main() {
     l := log.New(os.Stdout, " go-practice-service", log.LstdFlags)
+    
+    // Handler
+    hh := handlers.NewHello(l)
+
+    // ServeMux on index of port
+    sm := http.NewServeMux()
+    sm.Handle("/", hh)
+
+    // Server Configuration
+    s := http.Server{
+        Addr: ":8080",
+        Handler: sm,
+        ErrorLog: l,
+        ReadTimeout: 5 * time.Second, 
+        WriteTimeout: 10 * time.Second,
+        IdleTimeout: 120 * time.Second,
+    }
+
+    // Using goroutine to handle exiting gracefully
+    go func() {
+        l.Println("Started listening on Port: 8080")
+        err := s.ListenAndServe()
+        if err != nil {
+            l.Printf("Server Info: %s\n", err)
+            os.Exit(1)
+        }
+    }()
+
+    // Make Channel to listen to signals on the goroutine
+    c := make(chan os.Signal, 1)
+    signal.Notify(c, os.Interrupt)
+    signal.Notify(c, os.Kill)
+
+    // Listen to the channel and exit gracefully
+    sig := <-c
+    l.Println("Got Signal: ", sig)
+    ctx, cancel := context.WithTimeout(context.Background(), 30 * time.Second)
+    defer cancel()
+    s.Shutdown(ctx)
+
 }


### PR DESCRIPTION
This branch addresses #1 issue and creates a very simple HTTP server that returns 'Hello world' on its root. 
By default the port is set to 8080. 

We use a Handlers package to hold all of the logic for handling the HTTP request. Right now, I only have a 'HelloHandler' but this format could be easily added to by having more and more handlers.

I actually run the server inside of its own goroutine and wait in the main goroutine for it to send a OS Signal (i.e. exit) where we then gracefully exit the programme. I saw this recommended in Nic Jackson's series which I mention in #1. 

All in all, a little more resilient then the most basic approach to a HTTP service, but still simple nonetheless.